### PR TITLE
Replace the deprecated block_editor_settings filter

### DIFF
--- a/includes/class-editorskit-custom-css-classes.php
+++ b/includes/class-editorskit-custom-css-classes.php
@@ -62,7 +62,6 @@ class EditorsKit_Custom_CSS_Classes {
 	 * The Constructor.
 	 */
 	private function __construct() {
-
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );

--- a/includes/class-editorskit-custom-css-classes.php
+++ b/includes/class-editorskit-custom-css-classes.php
@@ -62,13 +62,12 @@ class EditorsKit_Custom_CSS_Classes {
 	 * The Constructor.
 	 */
 	private function __construct() {
-		global $wp_version;
 
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );
 
-		if ( $wp_version >= '5.8' ) {
+		if ( function_exists( 'get_block_editor_settings' ) ) {
 			add_filter( 'block_editor_settings_all', array( $this, 'block_editor_settings' ), 10, 2 );
 		} else {
 			add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );

--- a/includes/class-editorskit-custom-css-classes.php
+++ b/includes/class-editorskit-custom-css-classes.php
@@ -62,11 +62,17 @@ class EditorsKit_Custom_CSS_Classes {
 	 * The Constructor.
 	 */
 	private function __construct() {
+		global $wp_version;
+
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );
 
-		add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );
+		if ( $wp_version >= '5.8' ) {
+			add_filter( 'block_editor_settings_all', array( $this, 'block_editor_settings' ), 10, 2 );
+		} else {
+			add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );
+		}
 	}
 
 	/**

--- a/includes/class-editorskit-features-manager.php
+++ b/includes/class-editorskit-features-manager.php
@@ -63,11 +63,17 @@ class EditorsKit_Features_Manager {
 	 * The Constructor.
 	 */
 	private function __construct() {
+		global $wp_version;
+
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );
 
-		add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );
+		if ( $wp_version >= '5.8' ) {
+			add_filter( 'block_editor_settings_all', array( $this, 'block_editor_settings' ), 10, 2 );
+		} else {
+			add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );
+		}
 	}
 
 	/**

--- a/includes/class-editorskit-features-manager.php
+++ b/includes/class-editorskit-features-manager.php
@@ -63,13 +63,12 @@ class EditorsKit_Features_Manager {
 	 * The Constructor.
 	 */
 	private function __construct() {
-		global $wp_version;
 
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );
 
-		if ( $wp_version >= '5.8' ) {
+		if ( function_exists( 'get_block_editor_settings' ) ) {
 			add_filter( 'block_editor_settings_all', array( $this, 'block_editor_settings' ), 10, 2 );
 		} else {
 			add_filter( 'block_editor_settings', array( $this, 'block_editor_settings' ), 10, 2 );

--- a/includes/class-editorskit-features-manager.php
+++ b/includes/class-editorskit-features-manager.php
@@ -63,7 +63,6 @@ class EditorsKit_Features_Manager {
 	 * The Constructor.
 	 */
 	private function __construct() {
-
 		$this->version = EDITORSKIT_VERSION;
 		$this->slug    = 'editorskit';
 		$this->url     = untrailingslashit( plugins_url( '/', dirname( __FILE__ ) ) );

--- a/includes/class-editorskit-welcome.php
+++ b/includes/class-editorskit-welcome.php
@@ -69,8 +69,6 @@ if ( ! class_exists( 'EditorsKit_Welcome' ) ) {
 		 * @return void
 		 */
 		public function enqueue() {
-			global $wp_version;
-
 			// phpcs:ignore
 			if ( ! isset( $_GET['page'] ) || 'editorskit-getting-started' !== $_GET['page'] ) {
 				return;
@@ -118,7 +116,7 @@ if ( ! class_exists( 'EditorsKit_Welcome' ) ) {
 				false
 			);
 
-			if ( $wp_version >= '5.8' ) {
+			if ( function_exists( 'get_block_editor_settings' ) ) {
 				$block_editor_settings = 'block_editor_settings_all';
 			} else {
 				$block_editor_settings = 'block_editor_settings';

--- a/includes/class-editorskit-welcome.php
+++ b/includes/class-editorskit-welcome.php
@@ -69,6 +69,8 @@ if ( ! class_exists( 'EditorsKit_Welcome' ) ) {
 		 * @return void
 		 */
 		public function enqueue() {
+			global $wp_version;
+
 			// phpcs:ignore
 			if ( ! isset( $_GET['page'] ) || 'editorskit-getting-started' !== $_GET['page'] ) {
 				return;
@@ -116,6 +118,12 @@ if ( ! class_exists( 'EditorsKit_Welcome' ) ) {
 				false
 			);
 
+			if ( $wp_version >= '5.8' ) {
+				$block_editor_settings = 'block_editor_settings_all';
+			} else {
+				$block_editor_settings = 'block_editor_settings';
+			}
+
 			$global = array(
 				'url'             => EDITORSKIT_PLUGIN_URL,
 				'dir'             => EDITORSKIT_PLUGIN_DIR,
@@ -127,7 +135,7 @@ if ( ! class_exists( 'EditorsKit_Welcome' ) ) {
 					'typography' => get_option( 'editorskit_typography_addon_license_active' ),
 				),
 				'version'         => $this->version,
-				'editor_settings' => apply_filters( 'block_editor_settings', array(), '' ),
+				'editor_settings' => apply_filters( $block_editor_settings, array(), '' ),
 			);
 
 			wp_add_inline_script( $this->slug . '-admin', 'window.editorskitSettings = ' . wp_json_encode( $global ) . ';', 'before' );


### PR DESCRIPTION
Hi @phpbits, thanks for your work on this plugin.

I'm submitting this PR to update some deprecated filters in WP 5.8 released on 20th of this month.

Reference: https://make.wordpress.org/core/2021/06/16/block-editor-api-changes-to-support-multiple-admin-screens-in-wp-5-8/

I'm not sure if your approach is to maintain backward compatibility, if that's not the case, I'm glad with just updating the hook name.

Thanks