### PR TITLE
Remove isAvailable check from menu

### DIFF
--- a/src/extensions/components/autosave/components/menu.js
+++ b/src/extensions/components/autosave/components/menu.js
@@ -31,13 +31,13 @@ class ManageAutoSave extends Component {
 	}
 
 	sync() {
-		const { isAvailable, isActive, isDisabled, editorSettings } = this.props;
+		const { isActive, isDisabled, editorSettings } = this.props;
 
 		let autosaveInterval = 60;
 		const prompt = document.querySelector( '.editorskit-auto-save-disabled--label' );
 
 		//update autosave interval
-		if ( ! isActive && ! isDisabled && typeof isAvailable !== 'undefined' ) {
+		if ( ! isActive && ! isDisabled ) {
 			autosaveInterval = 259200; // 3days in seconds
 		}
 
@@ -86,7 +86,6 @@ class ManageAutoSave extends Component {
 
 export default compose( [
 	withSelect( () => ( {
-		isAvailable: select( 'core/edit-post' ).getPreference( 'features' ).editorskitAutoSave,
 		isActive: select( 'core/edit-post' ).isFeatureActive( 'editorskitAutoSave' ),
 		isDisabled: select( 'core/edit-post' ).isFeatureActive( 'disableEditorsKitAutosaveTools' ),
 		editorSettings: select( 'core/editor' ).getEditorSettings(),


### PR DESCRIPTION
User reported the plugin crashes in 11.4.0 ([WP.org](https://wordpress.org/support/topic/the-editorskit-plugin-corrupts-the-editor-when-used-with-gutenberg-11-4-0/))

The change in Gutenberg is here: https://github.com/WordPress/gutenberg/commit/292d9f2f8752c0aec610113f7f893739e32021e4#diff-0ae71183660dc527ae32f9b170c9508daa991ea8f6a7db7f356c953008b526faL8

They removed access to `.getPreference( 'features' )`

@phpbits I suspect this may be changing the behavior if both `isActive` and `isDisabled` have a default state of undefined. Is that the case here? any ideas on setting defaults there if so?